### PR TITLE
fix macOS rpath error

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,8 +2,6 @@
 include(FindPythonAnaconda.cmake)
 include_directories(${PYTHON_INCLUDE_DIR})
 
-message(STATUS "${PYTHON_INCLUDE_DIR}")
-
 set(CMAKE_SWIG_FLAGS "")
 set(CMAKE_SWIG_OUTDIR csmapi)
 set_source_files_properties(../csmapi.i

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,28 +2,31 @@
 include(FindPythonAnaconda.cmake)
 include_directories(${PYTHON_INCLUDE_DIR})
 
+message(STATUS "${PYTHON_INCLUDE_DIR}")
+
 set(CMAKE_SWIG_FLAGS "")
 set(CMAKE_SWIG_OUTDIR csmapi)
-set_source_files_properties(../csmapi.i 
+set_source_files_properties(../csmapi.i
                             PROPERTIES CPLUSPLUS ON)
 
 #Find dependencies
-find_path(CSM_INCLUDE_DIR NAMES csm.h 
-                          PATH_SUFFIXES csm 
+find_path(CSM_INCLUDE_DIR NAMES csm.h
+                          PATH_SUFFIXES csm
                           PATHS ${PYTHON_INCLUDE_DIR}/../)
 find_library(CSM_LIBRARY NAMES csmapi
             PATHS ${PYTHON_LIBRARY}/../)
 message("-- Found CSM Include: ${CSM_INCLUDE_DIR}")
 message("-- Found CSM Lib: ${CSM_LIBRARY}")
-
 include_directories(${CSM_INCLUDE_DIR})
 
-# Add and link 
+# Add and link
 swig_add_library(csmapi
-                 LANGUAGE python 
+                 LANGUAGE python
                  SOURCES ../csmapi.i)
 
 set_target_properties(_csmapi PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SWIG_OUTDIR})
+
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
 if (APPLE)
      set_target_properties(_csmapi PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
@@ -39,7 +42,7 @@ endif()
 # Move the static files to move
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
                ${CMAKE_CURRENT_BINARY_DIR}/setup.py
-               COPYONLY) 
+               COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
                ${CMAKE_CURRENT_BINARY_DIR}/csmapi/__init__.py
                COPYONLY)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-mkdir build && cd build
+mkdir -p build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX -DANACONDA_PYTHON_VERBOSE=ON ..
 make
 cd python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,19 +9,20 @@ requirements:
   build:
     - {{ compiler('cxx') }}  # [linux]
     - cmake >=3.10
+    - python
   host:
-    - libcsm
+    - csm
     - python
     - swig
   run:
-    - libcsm
+    - csm
     - python
     - numpy
 
 test:
   imports:
     - csmapi
-    
+
 about:
   home: https://github.com/USGS-Astrogeology/CSM-Swig
   license: None


### PR DESCRIPTION
Hopefully fixes error in macOS where the rpath for _csmapi.so is set incorrectly and it can't resolve libcsm.dylib's location. 