### PR TITLE
Adds settable ellipsoid to wrapper sort of

### DIFF
--- a/csmapi.i
+++ b/csmapi.i
@@ -8,3 +8,4 @@
 %include "geometricmodel.i"
 %include "rastergm.i"
 %include "plugin.i"
+%include "settableellipsoid.i"

--- a/fixture/model.cpp
+++ b/fixture/model.cpp
@@ -483,3 +483,12 @@ std::vector<double> FixtureSensorModel::getCrossCovarianceMatrix(
                    "Unsupported function",
                    "FixtureSensorModel::getCrossCovarianceMatrix");
 }
+
+csm::Ellipsoid FixtureSensorModel::getEllipsoid() const {
+    return csm::Ellipsoid(m_majorAxis, m_minorAxis);
+}
+
+void FixtureSensorModel::setEllipsoid(const csm::Ellipsoid &ellipsoid) {
+    m_majorAxis = ellipsoid.getSemiMajorRadius();
+    m_minorAxis = ellipsoid.getSemiMinorRadius();
+}

--- a/fixture/model.h
+++ b/fixture/model.h
@@ -188,16 +188,21 @@ public:
    virtual std::string getModelState() const;
 
    virtual void replaceModelState(const std::string& argState);
+   
+   virtual csm::Ellipsoid getEllipsoid() const;
 
+   virtual void setEllipsoid(const csm:: Ellipsoid &ellipsoid);
 
 
 private:
    // This private form of the g2i method is used to ensure thread safety.
    virtual csm::ImageCoord groundToImage(
-      const csm::EcefCoord& groundPt,
-      const std::vector<double> &adjustments,
-      double desiredPrecision = 0.001,
-      double* achievedPrecision = NULL,
-      csm::WarningList* warnings = NULL) const;
+   const csm::EcefCoord& groundPt,
+   const std::vector<double> &adjustments,
+   double desiredPrecision = 0.001,
+   double* achievedPrecision = NULL,
+   csm::WarningList* warnings = NULL) const;
+   double m_minorAxis;
+   double m_majorAxis;
 };
 #endif

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -58,3 +58,9 @@ def test_bad_ground_to_image(model):
     with pytest.warns(Warning) as w:
         img = model.groundToImage(gnd_coord, 0)
         assert len(w) == 1
+
+def test_ellipsoid_is_settable(model):
+    assert isinstance(csmapi.SettableEllipsoid.getEllipsoid(model), csmapi.Ellipsoid)
+    print(dir(model))
+    print(model.getEllipsoid(), type(model.getEllipsoid()))
+    return False

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -61,6 +61,3 @@ def test_bad_ground_to_image(model):
 
 def test_ellipsoid_is_settable(model):
     assert isinstance(csmapi.SettableEllipsoid.getEllipsoid(model), csmapi.Ellipsoid)
-    print(dir(model))
-    print(model.getEllipsoid(), type(model.getEllipsoid()))
-    return False

--- a/settableellipsoid.i
+++ b/settableellipsoid.i
@@ -1,0 +1,6 @@
+%module(package="csmapi") settableellipsoid
+%{
+    #include "SettableEllipsoid.h"
+%}
+
+%include "SettableEllipsoid.h"


### PR DESCRIPTION
This is partially working. The SettableEllipsoid is wrapped, but a few issues exist:

- The constructor is private so is not exposed. I do not think this is a huge issue as the csmapi does not appear to every expose the settable ellipsoid directly.
- The dynamic cast in plugin.i is casting the generic implementation to a RasterGM object. This is a problem when the implementation also inherits from SettableEllipsoid. I pulled the original example from [here](https://github.com/swig/swig/blob/cmake/Examples/test-suite/dynamic_cast.i#L72). I am not sure how to do the cast if/when implementation uses multiple inheritance. I suspect a message to the SWIG list is in order.

The test is currently set to return false. The first line of the test is passing as expected. The second is a print so that I can see what is going on with the classes / objects. This line is failing because the wrapped object is of type RasterGM as far as swig is concerned. In reality, the object inherits from both RasterGM and SettableEllipsoid.