### PR TITLE
Exposed sensorpartials

### DIFF
--- a/rastergm.i
+++ b/rastergm.i
@@ -1,4 +1,9 @@
 %module(package="csmapi") rastergm
+%include <std_pair.i>
+%include <std_vector.i>
+%template(SensorPartials) std::pair<double, double>;
+%template(VecSensorPartials) std::vector<std::pair<double, double>>;
+
 %{
     #include "RasterGM.h"
 %}
@@ -13,7 +18,7 @@
     } catch (const csm::Warning &e) {
         PyErr_WarnEx(PyExc_UserWarning, e.getMessage().c_str(), 1);
     }
-} 
+}
 %import model.i
 %import geometricmodel.i
 %import csm.i

--- a/rastergm.i
+++ b/rastergm.i
@@ -1,6 +1,7 @@
 %module(package="csmapi") rastergm
 %include <std_pair.i>
 %include <std_vector.i>
+%template(VecDouble) std::vector<double>;
 %template(SensorPartials) std::pair<double, double>;
 %template(VecSensorPartials) std::vector<std::pair<double, double>>;
 


### PR DESCRIPTION
These were just being exposed as anaonymous swig objects previously. This still needs to be tested by examining the return of an actual sensor model.